### PR TITLE
Fixup signing flow

### DIFF
--- a/windows/build.ps1
+++ b/windows/build.ps1
@@ -8,7 +8,7 @@ param(
   [string]$CatName       = "raspberrypi-rndis.cat",
   [string]$IssFile       = "setup.iss",
   [string]$OutputBase    = "rpi-usb-gadget-driver-setup",   # matches OutputBaseFilename in .iss
-  [string]$CertSubject   = "Raspberry Pi Ltd.",             # OR set $CertThumbprint below
+  [string]$CertSubject   = "Raspberry Pi Limited",             # OR set $CertThumbprint below
   [string]$CertThumbprint = "",                             # takes precedence if provided
   [string]$TimestampUrl  = "http://timestamp.digicert.com",
   [switch]$SignOutputExe = $true                            # extra sign step for the installer
@@ -16,6 +16,58 @@ param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+
+function Find-SignTool {
+  $candidates = @()
+  if ($env:SIGNTOOL) { $candidates += $env:SIGNTOOL }
+  
+  # Search for Windows SDK installations
+  $sdkBase = "${env:ProgramFiles(x86)}\Windows Kits\10\bin"
+  if (Test-Path $sdkBase) {
+    # Find the latest version directory
+    $versions = Get-ChildItem $sdkBase -Directory | Where-Object { $_.Name -match '^\d+\.\d+' } | Sort-Object Name -Descending
+    foreach ($ver in $versions) {
+      $candidates += Join-Path $ver.FullName "x64\signtool.exe"
+      $candidates += Join-Path $ver.FullName "x86\signtool.exe"
+      $candidates += Join-Path $ver.FullName "arm64\signtool.exe"
+    }
+  }
+  
+  # Also check if it's in PATH
+  $inPath = Get-Command "signtool.exe" -ErrorAction SilentlyContinue
+  if ($inPath) { $candidates += $inPath.Source }
+  
+  foreach ($c in $candidates) {
+    if ($c -and (Test-Path $c)) { return (Resolve-Path $c).Path }
+  }
+  throw "signtool.exe not found. Install Windows SDK or set `$env:SIGNTOOL to its path."
+}
+
+function Find-Inf2cat {
+  $candidates = @()
+  if ($env:INF2CAT) { $candidates += $env:INF2CAT }
+  
+  # Search for WDK installations
+  $wdkBase = "${env:ProgramFiles(x86)}\Windows Kits\10\bin"
+  if (Test-Path $wdkBase) {
+    # Find the latest version directory
+    $versions = Get-ChildItem $wdkBase -Directory | Where-Object { $_.Name -match '^\d+\.\d+' } | Sort-Object Name -Descending
+    foreach ($ver in $versions) {
+      $candidates += Join-Path $ver.FullName "x64\Inf2cat.exe"
+      $candidates += Join-Path $ver.FullName "x86\Inf2cat.exe"
+      $candidates += Join-Path $ver.FullName "arm64\Inf2cat.exe"
+    }
+  }
+  
+  # Also check if it's in PATH
+  $inPath = Get-Command "Inf2cat.exe" -ErrorAction SilentlyContinue
+  if ($inPath) { $candidates += $inPath.Source }
+  
+  foreach ($c in $candidates) {
+    if ($c -and (Test-Path $c)) { return (Resolve-Path $c).Path }
+  }
+  throw "Inf2cat.exe not found. Install Windows Driver Kit (WDK) or set `$env:INF2CAT to its path."
+}
 
 function Find-ISCC {
   $candidates = @()
@@ -35,7 +87,7 @@ function Find-ISCC {
   throw "ISCC.exe not found. Install Inno Setup 6 or set `$env:ISCC to its path."
 }
 
-function Set-FileSignature([string]$Path) {
+function Set-FileSignature([string]$Path, [string]$SignToolPath) {
   if (-not (Test-Path $Path)) { throw "File not found: $Path" }
   $args = @("sign","/fd","SHA256","/td","SHA256","/tr",$TimestampUrl)
   if ($CertThumbprint) {
@@ -45,16 +97,20 @@ function Set-FileSignature([string]$Path) {
   }
   $args += $Path
   Write-Host "Signing $Path ..."
-  & signtool.exe @args | Out-Host
+  & $SignToolPath @args | Out-Host
 }
+
+# --- Locate tools ---
+$SignTool = Find-SignTool
+$Inf2cat = Find-Inf2cat
 
 # --- Generate CAT for the INF ---
 Write-Host "Generating catalog for $InfName ..."
-& Inf2cat.exe /driver:. /os:10_X64,10_RS5_ARM64 | Out-Host
+& $Inf2cat /driver:. /os:10_X64,10_RS5_ARM64 | Out-Host
 if (-not (Test-Path $CatName)) { throw "Catalog not generated: $CatName" }
 
 # --- Sign the CAT (driver package signature) ---
-Set-FileSignature -Path (Resolve-Path $CatName).Path
+Set-FileSignature -Path (Resolve-Path $CatName).Path -SignToolPath $SignTool
 
 # Optional: show signature
 (Get-AuthenticodeSignature $CatName).Status | Out-Host
@@ -69,10 +125,17 @@ if ($CertThumbprint) {
     $defines += "/D""CertSubject=$CertSubject"""
 }
 # after locating $ISCC and building $defines, add the sign tool definition:
-$tool = '/Smysig=signtool.exe sign /fd SHA256 /td SHA256 /tr http://timestamp.digicert.com /sm /s My /sha1 $q' + $CertThumbprint + '$q $f'
+# For paths with spaces, use the short 8.3 path format to avoid quoting issues
+$SignToolShort = (New-Object -ComObject Scripting.FileSystemObject).GetFile($SignTool).ShortPath
+$toolCmd = "$SignToolShort sign /fd SHA256 /td SHA256 /tr http://timestamp.digicert.com `$f"
+$tool = "/Smysig=$toolCmd"
 
-# /Qp = quiet, progress
-& $ISCC "/Qp" $tool $defines (Resolve-Path $IssFile).Path | Out-Host
+# Build complete argument array
+# Removed /Qp for verbose output to debug argument issues
+Write-Host "ISCC Arguments:"
+$isccArgs = @($tool) + $defines + @((Resolve-Path $IssFile).Path)
+$isccArgs | ForEach-Object { Write-Host "  $_" }
+& $ISCC @isccArgs | Out-Host
 
 # Inno places output next to the script by default (per your .iss)
 $Installer = Join-Path (Get-Location) "$OutputBase.exe"
@@ -85,7 +148,7 @@ if (-not (Test-Path $Installer)) {
 # --- Sign the installer EXE as well ---
 # Inno will already sign (installer + uninstaller) via your [SignTool] block.
 # This extra sign step is harmless and can help if the in-process sign is skipped.
-if ($SignOutputExe) { Set-FileSignature -Path $Installer }
+if ($SignOutputExe) { Set-FileSignature -Path $Installer -SignToolPath $SignTool }
 
 Write-Host "Build complete:"
 Write-Host "  CAT: $((Resolve-Path $CatName).Path)"


### PR DESCRIPTION
Remove the explicit certificate thumbprint, and allow Windows to Do The Right Thing By Default.

This signing flow them becomes analagous to the one used in rpi-imager.